### PR TITLE
areatrigger_involvedrelation.sql fixed for areatrigger_involvedrelation....

### DIFF
--- a/_full_db/areatrigger_involvedrelation.sql
+++ b/_full_db/areatrigger_involvedrelation.sql
@@ -1,3 +1,37 @@
+--
+-- Copyright (C) 2005-2014 MaNGOS <http://getmangos.eu/>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+--
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `areatrigger_involvedrelation`
+--
+
+DROP TABLE IF EXISTS `areatrigger_involvedrelation`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `areatrigger_involvedrelation` (
@@ -6,4 +40,22 @@ CREATE TABLE `areatrigger_involvedrelation` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Trigger System';
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `areatrigger_involvedrelation`
+--
+
+LOCK TABLES `areatrigger_involvedrelation` WRITE;
 INSERT INTO `areatrigger_involvedrelation` VALUES (2946,6421),(3367,6025),(2327,4842),(2486,4811),(1205,2989),(482,1699),(362,1448),(302,1265),(231,984),(230,954),(225,944),(216,870),(196,578),(169,287),(98,201),(78,155),(178,503),(87,76),(88,62),(3986,8286),(4071,9193),(4200,9607),(4201,9608),(4291,9701),(4293,9716),(4298,9731),(4300,9752),(4301,9786),(1388,3505),(175,455),(246,1149),(232,984),(235,984),(4473,10269),(4475,10275),(2926,25),(522,1719),(171,273),(173,437),(2207,5156),(2726,6185),(4064,9160),(4170,9400),(4280,9700),(4581,10750),(4588,10772),(4963,11652),(4899,11890),(4950,12036),(4986,12263),(5003,12506),(5400,13816),(5401,13607),(822,2240),(3991,1658);
+
+/*!40000 ALTER TABLE `areatrigger_involvedrelation` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;


### PR DESCRIPTION
...sql usage

The make_full_db.sql was not adding the first SQL script (DROP TABLE) or
all of the second SQL script  (CREATE TABLE) of the
areatrigger_involvedrelation.sql file to the full_db.sql file. Only from
the PRIMARY KEY (`id`) part onwards was added to the full_db.sql file.

This fixes that.