### PR TITLE
Publish exact Wrath Warden check profiles

### DIFF
--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -37,6 +37,9 @@ DUMP = (ROOT / "Tools" / "dump_tables.sh").read_text(encoding="utf-8")
 WARDEN_PROFILE_UPDATE = (
     ROOT / "World" / "Updates" / "Rel22" / "Rel22_09_001_Warden_Check_Profiles.sql"
 )
+WARDEN_ASIAN_PROFILE_UPDATE = (
+    ROOT / "World" / "Updates" / "Rel22" / "Rel22_09_002_Warden_Asian_Profiles.sql"
+)
 
 
 def shell_function(name: str) -> str:
@@ -1312,6 +1315,153 @@ class WardenProfileTransitionTests(unittest.TestCase):
         commit_offset = sql.index("COMMIT;", version_offset)
         self.assertLess(signal_offset, version_offset)
         self.assertLess(version_offset, commit_offset)
+
+
+class WardenAsianProfileTransitionTests(unittest.TestCase):
+    @staticmethod
+    def update_sql() -> str:
+        if not WARDEN_ASIAN_PROFILE_UPDATE.is_file():
+            raise AssertionError(
+                "missing Rel22_09_002 Asian Warden profile update"
+            )
+        return WARDEN_ASIAN_PROFILE_UPDATE.read_text(encoding="utf-8")
+
+    @staticmethod
+    def parsed_rows(sql: str) -> list[tuple[object, ...]]:
+        rows = []
+        for match in WardenProfileTransitionTests._ROW_PATTERN.finditer(sql):
+            fields = match.groups()
+            rows.append(
+                (
+                    int(fields[0]),
+                    WardenProfileTransitionTests.binary_value(fields[1]),
+                    WardenProfileTransitionTests.binary_value(fields[2]),
+                    int(fields[3]),
+                    int(fields[4]),
+                    int(fields[5]),
+                    int(fields[6]),
+                    int(fields[7]),
+                    WardenProfileTransitionTests.binary_value(fields[8]),
+                    int(fields[9], 0),
+                    int(fields[10]),
+                    WardenProfileTransitionTests.binary_value(fields[11]),
+                    WardenProfileTransitionTests.binary_value(fields[12]),
+                )
+            )
+        return rows
+
+    def test_update_adds_only_the_three_exact_asian_profiles(self) -> None:
+        sql = self.update_sql()
+        rows = self.parsed_rows(sql)
+        locale_evidence = {
+            b"koKR": (
+                bytes.fromhex("39BCDE7E67F7DA4A366D15007DBAF3D438338E00"),
+                bytes.fromhex("ED9995EC9DB8"),
+            ),
+            b"zhCN": (
+                bytes.fromhex("53538853E7026786EB30FCB247D7E8179A3CAAF8"),
+                bytes.fromhex("E7A1AEE5AE9A"),
+            ),
+            b"zhTW": (
+                bytes.fromhex("ED14F2C71688B1DE9660F9CE04A62D63A9EB297A"),
+                bytes.fromhex("E7A2BAE5AE9A"),
+            ),
+        }
+        mpq_request = b"DBFilesClient\\AreaTable.dbc"
+        mem_expected = bytes.fromhex(
+            "B9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00"
+            "B8B3120000E82DFDFFFFA3441AD300"
+        )
+        expected_rows = []
+        for locale, (mpq_expected, lua_expected) in locale_evidence.items():
+            profile = (12340, b"Win", locale)
+            expected_rows.extend(
+                (
+                    profile + (65536, 87, 1, 10, 0, b"", 0, 0, b"", b""),
+                    profile
+                    + (
+                        1,
+                        152,
+                        1,
+                        20,
+                        3,
+                        b"",
+                        0,
+                        0,
+                        mpq_request,
+                        mpq_expected,
+                    ),
+                    profile
+                    + (2, 139, 1, 30, 3, b"", 0, 0, b"OKAY", lua_expected),
+                    profile
+                    + (
+                        3,
+                        243,
+                        1,
+                        40,
+                        1,
+                        b"",
+                        0x007DA8C0,
+                        40,
+                        b"",
+                        mem_expected,
+                    ),
+                )
+            )
+
+        self.assertEqual(len(rows), 12)
+        self.assertCountEqual(rows, expected_rows)
+        self.assertEqual({row[2] for row in rows}, set(locale_evidence))
+
+    def test_update_preserves_existing_profiles_and_advances_content(self) -> None:
+        sql = self.update_sql()
+        self.assertNotIn("DELETE FROM `warden_checks`", sql)
+        self.assertIn("SET @cOldContent = '001';", sql)
+        self.assertIn("SET @cNewContent = '002';", sql)
+        self.assertIn("START TRANSACTION;", sql)
+        self.assertIn("ROLLBACK;", sql)
+        self.assertIn(
+            "Stop mangosd and deploy this update with the matching server revision",
+            sql,
+        )
+
+    def test_update_rejects_any_preexisting_asian_profile_rows(self) -> None:
+        sql = self.update_sql()
+        start = sql.index("        IF EXISTS (")
+        end = sql.index("        END IF;", start)
+        guard = sql[start:end]
+
+        self.assertRegex(
+            guard,
+            r"(?is)WHERE\s+`build`\s*=\s*12340\s+AND\s+"
+            r"`platform`\s*=\s*0x57696E\s+AND\s+`locale`\s+IN\s*\(",
+        )
+        for locale in ("0x6B6F4B52", "0x7A68434E", "0x7A685457"):
+            self.assertIn(locale, guard)
+        self.assertIn("SIGNAL SQLSTATE '45000'", guard)
+
+    def test_update_validates_all_twelve_rows_before_version_publish(self) -> None:
+        sql = self.update_sql()
+        validation_start = sql.index(
+            "        IF (SELECT COUNT(*) FROM `warden_checks`"
+        )
+        validation_end = sql.index("        END IF;", validation_start)
+        validation = sql[validation_start:validation_end]
+
+        self.assertRegex(validation, r"(?is)COUNT\(\*\).*?<>\s*12")
+        self.assertRegex(
+            validation,
+            r"(?is)COUNT\(DISTINCT\s+`build`,`platform`,`locale`\).*?<>\s*3",
+        )
+        self.assertRegex(
+            validation,
+            r"(?is)HAVING\s+COUNT\(\*\)\s*<>\s*4\s+OR\s+"
+            r"SUM\(`enabled`\s*=\s*1\)\s*<>\s*4",
+        )
+        self.assertLess(
+            sql.index("SIGNAL SQLSTATE '45000'", validation_start),
+            sql.index("INSERT INTO `db_version`"),
+        )
 
 
 if __name__ == "__main__":

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -34,6 +34,9 @@ ROOT = Path(__file__).resolve().parents[2]
 INSTALL = (ROOT / "InstallDatabases.sh").read_text(encoding="utf-8")
 BACKUP = (ROOT / "Tools" / "backupDB.cmd").read_text(encoding="utf-8")
 DUMP = (ROOT / "Tools" / "dump_tables.sh").read_text(encoding="utf-8")
+WARDEN_PROFILE_UPDATE = (
+    ROOT / "World" / "Updates" / "Rel22" / "Rel22_09_001_Warden_Check_Profiles.sql"
+)
 
 
 def shell_function(name: str) -> str:
@@ -1104,6 +1107,211 @@ class BackupPublicationRollbackTests(unittest.TestCase):
             self.assertIn("INSERT INTO sample VALUES\n(1);", published)
             self.assertFalse((root / "sample.sql.new").exists())
 
+
+class WardenProfileTransitionTests(unittest.TestCase):
+    _ROW_PATTERN = re.compile(
+        r"\(\s*(\d+)\s*,\s*(0x[0-9A-F]+)\s*,\s*(0x[0-9A-F]+)\s*,"
+        r"\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,"
+        r"\s*(\d+)\s*,\s*(X''|0x[0-9A-F]+)\s*,"
+        r"\s*(0x[0-9A-F]+|\d+)\s*,\s*(\d+)\s*,"
+        r"\s*(X''|0x[0-9A-F]+)\s*,\s*(X''|0x[0-9A-F]+)\s*,"
+        r"\s*'[^']*'\s*\)",
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def update_sql() -> str:
+        if not WARDEN_PROFILE_UPDATE.is_file():
+            raise AssertionError(
+                f"missing Warden profile transition: {WARDEN_PROFILE_UPDATE}"
+            )
+        return WARDEN_PROFILE_UPDATE.read_text(encoding="utf-8")
+
+    @staticmethod
+    def binary_value(token: str) -> bytes:
+        if token.upper() == "X''":
+            return b""
+        return bytes.fromhex(token[2:])
+
+    def parsed_rows(self, sql: str) -> list[tuple[object, ...]]:
+        rows = []
+        for match in self._ROW_PATTERN.finditer(sql):
+            fields = match.groups()
+            rows.append(
+                (
+                    int(fields[0]),
+                    self.binary_value(fields[1]),
+                    self.binary_value(fields[2]),
+                    int(fields[3]),
+                    int(fields[4]),
+                    int(fields[5]),
+                    int(fields[6]),
+                    int(fields[7]),
+                    self.binary_value(fields[8]),
+                    int(fields[9], 0),
+                    int(fields[10]),
+                    self.binary_value(fields[11]),
+                    self.binary_value(fields[12]),
+                )
+            )
+        return rows
+
+    def test_transition_publishes_only_the_exact_wrath_profiles(self) -> None:
+        sql = self.update_sql()
+        rows = self.parsed_rows(sql)
+        locale_evidence = {
+            b"enUS": (
+                bytes.fromhex("8C7CED99F8DDDD48296551EFE05A2CF27B26F818"),
+                b"Okay",
+            ),
+            b"enGB": (
+                bytes.fromhex("8C7CED99F8DDDD48296551EFE05A2CF27B26F818"),
+                b"Okay",
+            ),
+            b"deDE": (
+                bytes.fromhex("0B4D01BDEB4F47DE030B57D81506093EB887EE0B"),
+                b"OK",
+            ),
+            b"esES": (
+                bytes.fromhex("20EC8371EC168B4723AF6DE3AFE81D46843726F4"),
+                b"Aceptar",
+            ),
+            b"esMX": (
+                bytes.fromhex("0E39F4AF09E3CF08925D41E61FBAC8EE16478FC9"),
+                b"Aceptar",
+            ),
+            b"frFR": (
+                bytes.fromhex("E6F5A0C5C63056F63097420AE29B47ACA2E4D496"),
+                b"OK",
+            ),
+            b"ruRU": (
+                bytes.fromhex("329BF203079002D36E05EBF54BD5746AA37E47C8"),
+                bytes.fromhex("D09ED09A"),
+            ),
+        }
+        mpq_request = b"DBFilesClient\\AreaTable.dbc"
+        mem_expected = bytes.fromhex(
+            "B9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00"
+            "B8B3120000E82DFDFFFFA3441AD300"
+        )
+        expected_rows = []
+        for locale, (mpq_expected, lua_expected) in locale_evidence.items():
+            profile = (12340, b"Win", locale)
+            expected_rows.extend(
+                (
+                    profile + (65536, 87, 1, 10, 0, b"", 0, 0, b"", b""),
+                    profile
+                    + (
+                        1,
+                        152,
+                        1,
+                        20,
+                        3,
+                        b"",
+                        0,
+                        0,
+                        mpq_request,
+                        mpq_expected,
+                    ),
+                    profile
+                    + (2, 139, 1, 30, 3, b"", 0, 0, b"OKAY", lua_expected),
+                    profile
+                    + (
+                        3,
+                        243,
+                        1,
+                        40,
+                        1,
+                        b"",
+                        0x007DA8C0,
+                        40,
+                        b"",
+                        mem_expected,
+                    ),
+                )
+            )
+
+        self.assertEqual(len(rows), 28)
+        self.assertCountEqual(rows, expected_rows)
+        self.assertEqual({row[2] for row in rows}, set(locale_evidence))
+        for locale in locale_evidence:
+            profile_rows = [row for row in rows if row[2] == locale]
+            self.assertEqual(len(profile_rows), 4)
+            self.assertTrue(all(row[5] == 1 for row in profile_rows))
+
+    def test_transition_preserves_unrelated_catalogue_rows(self) -> None:
+        sql = self.update_sql()
+        deletes = re.findall(r"(?is)\bDELETE\s+FROM\s+`warden_checks`.*?;", sql)
+        self.assertEqual(len(deletes), 1)
+        self.assertRegex(
+            deletes[0],
+            r"(?is)^DELETE\s+FROM\s+`warden_checks`\s+"
+            r"WHERE\s+`build`\s*=\s*12340\s+AND\s+"
+            r"`platform`\s*=\s*0x57696E\s*;$",
+        )
+        self.assertNotRegex(
+            sql,
+            r"(?i)\b(?:TRUNCATE|DROP)\s+(?:TABLE\s+)?`warden_checks`",
+        )
+
+    def test_all_profile_validations_are_scoped_to_wrath_windows(self) -> None:
+        sql = self.update_sql()
+        validation = re.search(
+            r"(?is)IF\s*\(SELECT COUNT\(\*\).*?"
+            r"SIGNAL SQLSTATE '45000'.*?;",
+            sql,
+        )
+        self.assertIsNotNone(validation)
+        validation_sql = validation.group(0)
+        queries = re.findall(
+            r"(?is)(?:FROM|JOIN)\s+`warden_checks`(.*?)(?=\)|GROUP\s+BY)",
+            validation_sql,
+        )
+        self.assertEqual(len(queries), 4)
+        for query in queries:
+            self.assertRegex(
+                query,
+                r"(?is)WHERE\s+`build`\s*=\s*12340\s+AND\s+"
+                r"`platform`\s*=\s*0x57696E\b",
+            )
+        self.assertRegex(validation_sql, r"(?is)COUNT\(\*\).*?<>\s*28")
+        self.assertRegex(
+            validation_sql,
+            r"(?is)COUNT\(DISTINCT\s+`build`,`platform`,`locale`\).*?<>\s*7",
+        )
+        self.assertRegex(
+            validation_sql,
+            r"(?is)HAVING\s+COUNT\(\*\)\s*<>\s*4\s+OR\s+"
+            r"SUM\(`enabled`\s*=\s*1\)\s*<>\s*4",
+        )
+
+    def test_transition_rolls_back_and_returns_failure_before_version_publish(
+        self,
+    ) -> None:
+        sql = self.update_sql()
+        self.assertRegex(
+            sql,
+            r"(?s)SET @cOldVersion\s*=\s*'22'.*?"
+            r"@cOldStructure\s*=\s*'08'.*?@cOldContent\s*=\s*'001'",
+        )
+        self.assertRegex(
+            sql,
+            r"(?s)SET @cNewVersion\s*=\s*'22'.*?"
+            r"@cNewStructure\s*=\s*'09'.*?@cNewContent\s*=\s*'001'",
+        )
+        handler = re.search(
+            r"(?is)DECLARE EXIT HANDLER FOR SQLEXCEPTION\s+BEGIN(.*?)END;",
+            sql,
+        )
+        self.assertIsNotNone(handler)
+        self.assertRegex(handler.group(1), r"(?i)\bROLLBACK\s*;")
+        self.assertRegex(handler.group(1), r"(?i)\bRESIGNAL\s*;")
+        self.assertIn("START TRANSACTION;", sql)
+        signal_offset = sql.index("SIGNAL SQLSTATE '45000'")
+        version_offset = sql.index("INSERT INTO `db_version`")
+        commit_offset = sql.index("COMMIT;", version_offset)
+        self.assertLess(signal_offset, version_offset)
+        self.assertLess(version_offset, commit_offset)
 
 
 if __name__ == "__main__":

--- a/World/Updates/Rel22/Rel22_09_001_Warden_Check_Profiles.sql
+++ b/World/Updates/Rel22/Rel22_09_001_Warden_Check_Profiles.sql
@@ -38,9 +38,9 @@ BEGIN
     IF (@cCurResult = @cOldResult) THEN
         START TRANSACTION;
 
-        -- Replace only this exact build/platform seed. Unrelated operator or
-        -- future-profile rows remain untouched and outside the validation
-        -- scope below.
+        -- Replace the complete 12340/Win seed, including any operator-added
+        -- rows in that scope. Rows for other profiles remain untouched, but a
+        -- profile absent from the paired core's module catalogue stops mangosd.
         DELETE FROM `warden_checks`
         WHERE `build` = 12340 AND `platform` = 0x57696E;
 

--- a/World/Updates/Rel22/Rel22_09_001_Warden_Check_Profiles.sql
+++ b/World/Updates/Rel22/Rel22_09_001_Warden_Check_Profiles.sql
@@ -1,0 +1,194 @@
+-- -------------------------------------------------------------------------
+-- Seed the exact Wrath 3.3.5a.12340 Warden check profiles.
+-- The typed schema was created by Rel22_08_001; this update changes data only.
+-- -------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        SHOW ERRORS;
+        SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+               @cCurResult AS `===== DB is on Version: =====`;
+        RESIGNAL;
+    END;
+
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '08';
+    SET @cOldContent = '001';
+
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '09';
+    SET @cNewContent = '001';
+    SET @cNewDescription = 'Warden_Check_Profiles';
+    SET @cNewComment = 'Seed exact Wrath 3.3.5a.12340 Warden check profiles';
+
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version` = @cOldVersion AND `structure` = @cOldStructure AND `content` = @cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version` = @cNewVersion AND `structure` = @cNewStructure AND `content` = @cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN
+        START TRANSACTION;
+
+        -- Replace only this exact build/platform seed. Unrelated operator or
+        -- future-profile rows remain untouched and outside the validation
+        -- scope below.
+        DELETE FROM `warden_checks`
+        WHERE `build` = 12340 AND `platform` = 0x57696E;
+
+        INSERT INTO `warden_checks`
+        (`build`,`platform`,`locale`,`check_id`,`type`,`enabled`,`sort_order`,
+         `evidence_class`,`module`,`address`,`length`,`request`,`expected`,`comment`)
+        VALUES
+        (12340,0x57696E,0x656E5553,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x656E5553,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x8C7CED99F8DDDD48296551EFE05A2CF27B26F818,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x656E5553,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F6B6179,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x656E5553,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x656E4742,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x656E4742,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x8C7CED99F8DDDD48296551EFE05A2CF27B26F818,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x656E4742,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F6B6179,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x656E4742,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x64654445,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x64654445,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x0B4D01BDEB4F47DE030B57D81506093EB887EE0B,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x64654445,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F4B,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x64654445,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x65734553,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x65734553,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x20EC8371EC168B4723AF6DE3AFE81D46843726F4,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x65734553,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x41636570746172,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x65734553,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x65734D58,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x65734D58,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x0E39F4AF09E3CF08925D41E61FBAC8EE16478FC9,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x65734D58,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x41636570746172,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x65734D58,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x66724652,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x66724652,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0xE6F5A0C5C63056F63097420AE29B47ACA2E4D496,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x66724652,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F4B,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x66724652,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x72755255,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x72755255,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x329BF203079002D36E05EBF54BD5746AA37E47C8,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x72755255,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xD09ED09A,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x72755255,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant');
+
+        IF (SELECT COUNT(*) FROM `warden_checks`
+            WHERE `build` = 12340 AND `platform` = 0x57696E) <> 28
+           OR (SELECT COUNT(*) FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E
+                 AND `enabled` = 1) <> 28
+           OR (SELECT COUNT(DISTINCT `build`,`platform`,`locale`)
+               FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E) <> 7
+           OR EXISTS (
+               SELECT 1 FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E
+               GROUP BY `build`,`platform`,`locale`
+               HAVING COUNT(*) <> 4 OR SUM(`enabled` = 1) <> 4
+           ) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Warden check profile validation failed';
+        END IF;
+
+        INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure,
+            @cNewContent, @cNewDescription, @cNewComment);
+        SET @cNewResult := (SELECT `description` FROM `db_version`
+            WHERE `version` = @cNewVersion AND `structure` = @cNewStructure
+              AND `content` = @cNewContent);
+        COMMIT;
+        SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,
+               @cNewResult AS `===== DB is now on Version =====`;
+    ELSE
+        IF (@cCurResult = @cNewResult) THEN
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                   @cCurResult AS `===== DB is already on Version =====`;
+        ELSE
+            IF (@cCurResult IS NULL) THEN
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+                       'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure,
+                    '_', @cCurContent, ' - ', @cCurResult);
+                SET @cOldOutput = CONCAT(@cOldVersion, '_', @cOldStructure,
+                    '_', @cOldContent, ' - ',
+                    COALESCE(@cOldResult, 'IS NOT APPLIED'));
+                SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                       @cOldOutput AS `=== Expected ===`,
+                       @cCurOutput AS `===== Found Version =====`;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+CALL update_mangos();
+
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/World/Updates/Rel22/Rel22_09_002_Warden_Asian_Profiles.sql
+++ b/World/Updates/Rel22/Rel22_09_002_Warden_Asian_Profiles.sql
@@ -1,0 +1,151 @@
+-- -------------------------------------------------------------------------
+-- Add the exact Asian Wrath 3.3.5a.12340 Warden check profiles.
+-- Existing profiles and operator-added rows remain untouched.
+-- Stop mangosd and deploy this update with the matching server revision;
+-- strict module/profile coverage rejects either half deployed on its own.
+-- -------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        SHOW ERRORS;
+        SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+               @cCurResult AS `===== DB is on Version: =====`;
+        RESIGNAL;
+    END;
+
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '09';
+    SET @cOldContent = '001';
+
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '09';
+    SET @cNewContent = '002';
+    SET @cNewDescription = 'Warden_Asian_Profiles';
+    SET @cNewComment = 'Add exact Wrath 3.3.5a.12340 Asian Warden check profiles';
+
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version` = @cOldVersion AND `structure` = @cOldStructure AND `content` = @cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version` = @cNewVersion AND `structure` = @cNewStructure AND `content` = @cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN
+        START TRANSACTION;
+
+        IF EXISTS (
+            SELECT 1 FROM `warden_checks`
+            WHERE `build` = 12340 AND `platform` = 0x57696E
+              AND `locale` IN (0x6B6F4B52,0x7A68434E,0x7A685457)
+        ) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Existing 12340/Win Asian Warden rows conflict; back up and reconcile them, then re-run';
+        END IF;
+
+        INSERT INTO `warden_checks`
+        (`build`,`platform`,`locale`,`check_id`,`type`,`enabled`,`sort_order`,
+         `evidence_class`,`module`,`address`,`length`,`request`,`expected`,`comment`)
+        VALUES
+        (12340,0x57696E,0x6B6F4B52,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x6B6F4B52,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x39BCDE7E67F7DA4A366D15007DBAF3D438338E00,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x6B6F4B52,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xED9995EC9DB8,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x6B6F4B52,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x7A68434E,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x7A68434E,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x53538853E7026786EB30FCB247D7E8179A3CAAF8,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x7A68434E,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xE7A1AEE5AE9A,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x7A68434E,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant'),
+
+        (12340,0x57696E,0x7A685457,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (12340,0x57696E,0x7A685457,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0xED14F2C71688B1DE9660F9CE04A62D63A9EB297A,
+         'Effective AreaTable baseline; corroboration only'),
+        (12340,0x57696E,0x7A685457,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xE7A2BAE5AE9A,'Localized OKAY callback; corroboration only'),
+        (12340,0x57696E,0x7A685457,3,243,1,40,1,X'',
+         0x007DA8C0,40,X'',
+         0xB9601AD300E8769DF9FFE851FBFFFF688C29AF0068D816AF00B8B3120000E82DFDFFFFA3441AD300,
+         'Exact 12340 Warden bootstrap invariant');
+
+        IF (SELECT COUNT(*) FROM `warden_checks`
+            WHERE `build` = 12340 AND `platform` = 0x57696E
+              AND `locale` IN (0x6B6F4B52,0x7A68434E,0x7A685457)) <> 12
+           OR (SELECT COUNT(*) FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E
+                 AND `locale` IN (0x6B6F4B52,0x7A68434E,0x7A685457)
+                 AND `enabled` = 1) <> 12
+           OR (SELECT COUNT(DISTINCT `build`,`platform`,`locale`)
+               FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E
+                 AND `locale` IN (0x6B6F4B52,0x7A68434E,0x7A685457)) <> 3
+           OR EXISTS (
+               SELECT 1 FROM `warden_checks`
+               WHERE `build` = 12340 AND `platform` = 0x57696E
+                 AND `locale` IN (0x6B6F4B52,0x7A68434E,0x7A685457)
+               GROUP BY `build`,`platform`,`locale`
+               HAVING COUNT(*) <> 4 OR SUM(`enabled` = 1) <> 4
+           ) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Warden Asian profile validation failed';
+        END IF;
+
+        INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure,
+            @cNewContent, @cNewDescription, @cNewComment);
+        SET @cNewResult := (SELECT `description` FROM `db_version`
+            WHERE `version` = @cNewVersion AND `structure` = @cNewStructure
+              AND `content` = @cNewContent);
+        COMMIT;
+        SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,
+               @cNewResult AS `===== DB is now on Version =====`;
+    ELSE
+        IF (@cCurResult = @cNewResult) THEN
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                   @cCurResult AS `===== DB is already on Version =====`;
+        ELSE
+            IF (@cCurResult IS NULL) THEN
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+                       'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure,
+                    '_', @cCurContent, ' - ', @cCurResult);
+                SET @cOldOutput = CONCAT(@cOldVersion, '_', @cOldStructure,
+                    '_', @cOldContent, ' - ',
+                    COALESCE(@cOldResult, 'IS NOT APPLIED'));
+                SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                       @cOldOutput AS `=== Expected ===`,
+                       @cCurOutput AS `===== Found Version =====`;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+CALL update_mangos();
+
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
## Summary

- publish the typed `warden_checks` catalogue for exact Wrath 3.3.5 build 12340 Win clients
- seed Timing, MPQ, Lua, and MEM checks for all ten supported locales
- add the koKR, zhCN, and zhTW profiles without overwriting pre-existing rows
- advance the World database through `22.09.001 Warden_Check_Profiles` and `22.09.002 Warden_Asian_Profiles`
- keep all changes in house-format update files; no Base, Setup, or FullDB files are changed

## Deployment

Paired server PR: mangostwo/server#271. Merge and apply this database PR first; the server deliberately refuses startup without a complete matching catalogue.

## Verification

- database transition suite: 29/29 passed
- MariaDB 10.11 first application and idempotent replay passed
- disposable conflict fixture proved rollback without partial Asian-profile publication
- final live catalogue: 40/40 enabled rows across ten exact profiles
- live enUS, enGB, deDE, esES, esMX, frFR, ruRU, koKR, zhCN, and zhTW clients passed Timing, locale MPQ, locale Lua, and MEM validation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/database/177)
<!-- Reviewable:end -->
